### PR TITLE
Update copyright year to 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Achim Grolimund
+Copyright (c) 2024 Achim Grolimund
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GrolimundSolutions/go-multistage-builder
 
-go 1.21
+go 1.23
 
 require (
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
This pull request includes updates to the project license and Go module version.

Updates:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright year to 2024.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from 1.21 to 1.23.

#hacktoberfest